### PR TITLE
Add settings screen with DataStore and storage check

### DIFF
--- a/app/src/main/java/com/example/realsensecapture/MainActivity.kt
+++ b/app/src/main/java/com/example/realsensecapture/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.realsensecapture
 
 import android.os.Bundle
+import android.os.StatFs
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.FloatingActionButton
@@ -13,14 +14,17 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.padding
 import com.example.realsensecapture.ui.PreviewScreen
+import com.example.realsensecapture.ui.SettingsRepository
 import com.example.realsensecapture.rsnative.NativeBridge
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val settingsRepository = SettingsRepository(this)
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
             val scope = rememberCoroutineScope()
@@ -29,6 +33,13 @@ class MainActivity : ComponentActivity() {
                 floatingActionButton = {
                     FloatingActionButton(onClick = {
                         scope.launch {
+                            val threshold = settingsRepository.thresholdFlow.first()
+                            val statFs = StatFs(filesDir.absolutePath)
+                            val available = statFs.availableBytes
+                            if (available < threshold) {
+                                snackbarHostState.showSnackbar("Not enough space")
+                                return@launch
+                            }
                             val ok = withContext(Dispatchers.IO) {
                                 NativeBridge.captureBurst(filesDir.absolutePath)
                             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ composeCompiler = "1.5.14"
 composeBom = "2024.08.00"
 coreKtx = "1.13.1"
 activityCompose = "1.9.1"
+dataStore = "1.1.1"
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "androidGradlePlugin" }
@@ -21,4 +22,5 @@ androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "dataStore" }
 

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.datastore.preferences)
     debugImplementation(libs.androidx.compose.ui.tooling)
     implementation(project(":rsnative"))
 }

--- a/ui/src/main/java/com/example/realsensecapture/ui/SettingsRepository.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/SettingsRepository.kt
@@ -1,0 +1,35 @@
+package com.example.realsensecapture.ui
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore by preferencesDataStore("settings")
+
+class SettingsRepository(private val context: Context) {
+    private val resolutionKey = stringPreferencesKey("resolution")
+    private val fpsKey = intPreferencesKey("fps")
+    private val thresholdKey = longPreferencesKey("threshold")
+
+    val resolutionFlow: Flow<String> = context.dataStore.data.map { it[resolutionKey] ?: "640x480" }
+    val fpsFlow: Flow<Int> = context.dataStore.data.map { it[fpsKey] ?: 30 }
+    val thresholdFlow: Flow<Long> = context.dataStore.data.map { it[thresholdKey] ?: 100L * 1024 * 1024 }
+
+    suspend fun setResolution(value: String) {
+        context.dataStore.edit { it[resolutionKey] = value }
+    }
+
+    suspend fun setFps(value: Int) {
+        context.dataStore.edit { it[fpsKey] = value }
+    }
+
+    suspend fun setThreshold(value: Long) {
+        context.dataStore.edit { it[thresholdKey] = value }
+    }
+}
+

--- a/ui/src/main/java/com/example/realsensecapture/ui/SettingsScreen.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/SettingsScreen.kt
@@ -1,0 +1,45 @@
+package com.example.realsensecapture.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+
+@Composable
+fun SettingsScreen(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val repository = remember { SettingsRepository(context) }
+    val scope = rememberCoroutineScope()
+
+    val resolution by repository.resolutionFlow.collectAsState(initial = "640x480")
+    val fps by repository.fpsFlow.collectAsState(initial = 30)
+    val threshold by repository.thresholdFlow.collectAsState(initial = 100L * 1024 * 1024)
+
+    Column(modifier.padding(16.dp)) {
+        OutlinedTextField(
+            value = resolution,
+            onValueChange = { new -> scope.launch { repository.setResolution(new) } },
+            label = { Text("Resolution") }
+        )
+        OutlinedTextField(
+            value = fps.toString(),
+            onValueChange = { new -> new.toIntOrNull()?.let { scope.launch { repository.setFps(it) } } },
+            label = { Text("FPS") }
+        )
+        OutlinedTextField(
+            value = threshold.toString(),
+            onValueChange = { new -> new.toLongOrNull()?.let { scope.launch { repository.setThreshold(it) } } },
+            label = { Text("Free space threshold (bytes)") }
+        )
+    }
+}
+


### PR DESCRIPTION
## Summary
- add DataStore-backed SettingsRepository and SettingsScreen to manage resolution, FPS, and free space threshold
- check available storage with StatFs before capturing
- wire up DataStore dependency

## Testing
- `./gradlew assemble` *(fails: License for package NDK (Side by side) 26.1.10909125 not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68933acee7e0832a89dbab9338f23bb5