### PR TITLE
Add session capture folder and Room metadata storage

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.kotlinCompose)
+    alias(libs.plugins.kotlinKapt)
 }
 
 android {
@@ -44,5 +45,8 @@ dependencies {
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    kapt(libs.androidx.room.compiler)
     debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/app/src/main/java/com/example/realsensecapture/MainActivity.kt
+++ b/app/src/main/java/com/example/realsensecapture/MainActivity.kt
@@ -2,6 +2,9 @@ package com.example.realsensecapture
 
 import android.os.Bundle
 import android.os.StatFs
+import java.io.File
+import java.time.Instant
+import org.json.JSONObject
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.FloatingActionButton
@@ -16,6 +19,8 @@ import androidx.compose.foundation.layout.padding
 import com.example.realsensecapture.ui.PreviewScreen
 import com.example.realsensecapture.ui.SettingsRepository
 import com.example.realsensecapture.rsnative.NativeBridge
+import com.example.realsensecapture.data.AppDatabase
+import com.example.realsensecapture.data.SessionEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -25,6 +30,8 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val settingsRepository = SettingsRepository(this)
+        val db = AppDatabase.getInstance(this)
+        val sessionDao = db.sessionDao()
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
             val scope = rememberCoroutineScope()
@@ -40,10 +47,38 @@ class MainActivity : ComponentActivity() {
                                 snackbarHostState.showSnackbar("Not enough space")
                                 return@launch
                             }
+                            val timestamp = Instant.now()
+                            val sessionDir = File(filesDir, "Captures/Session-${timestamp.toString()}").apply { mkdirs() }
                             val ok = withContext(Dispatchers.IO) {
-                                NativeBridge.captureBurst(filesDir.absolutePath)
+                                NativeBridge.captureBurst(sessionDir.absolutePath)
                             }
                             if (ok) {
+                                val rgbCount = sessionDir.listFiles { _, name ->
+                                    name.startsWith("rgb_") && name.endsWith(".jpg")
+                                }?.size ?: 0
+                                val noteSrc = File(filesDir, "note.m4a")
+                                val hasNote = if (noteSrc.exists()) {
+                                    noteSrc.renameTo(File(sessionDir, "note.m4a"))
+                                } else {
+                                    false
+                                }
+                                val timestampIso = timestamp.toString()
+                                val meta = JSONObject().apply {
+                                    put("timestamp", timestampIso)
+                                    put("rgbCount", rgbCount)
+                                    put("hasNote", hasNote)
+                                }
+                                File(sessionDir, "meta.json").writeText(meta.toString())
+                                withContext(Dispatchers.IO) {
+                                    sessionDao.insert(
+                                        SessionEntity(
+                                            folderPath = sessionDir.absolutePath,
+                                            timestamp = timestamp.toEpochMilli(),
+                                            rgbCount = rgbCount,
+                                            hasNote = hasNote
+                                        )
+                                    )
+                                }
                                 snackbarHostState.showSnackbar("Saved")
                             }
                         }

--- a/app/src/main/java/com/example/realsensecapture/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/realsensecapture/data/AppDatabase.kt
@@ -1,0 +1,25 @@
+package com.example.realsensecapture.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+
+@Database(entities = [SessionEntity::class], version = 1)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun sessionDao(): SessionDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: AppDatabase? = null
+
+        fun getInstance(context: Context): AppDatabase =
+            INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "sessions.db"
+                ).build().also { INSTANCE = it }
+            }
+    }
+}

--- a/app/src/main/java/com/example/realsensecapture/data/SessionDao.kt
+++ b/app/src/main/java/com/example/realsensecapture/data/SessionDao.kt
@@ -1,0 +1,10 @@
+package com.example.realsensecapture.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+
+@Dao
+interface SessionDao {
+    @Insert
+    suspend fun insert(session: SessionEntity)
+}

--- a/app/src/main/java/com/example/realsensecapture/data/SessionEntity.kt
+++ b/app/src/main/java/com/example/realsensecapture/data/SessionEntity.kt
@@ -1,0 +1,13 @@
+package com.example.realsensecapture.data
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "sessions")
+data class SessionEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val folderPath: String,
+    val timestamp: Long,
+    val rgbCount: Int,
+    val hasNote: Boolean
+)

--- a/app/src/main/java/com/example/realsensecapture/data/SessionRepository.kt
+++ b/app/src/main/java/com/example/realsensecapture/data/SessionRepository.kt
@@ -1,0 +1,5 @@
+package com.example.realsensecapture.data
+
+class SessionRepository(private val dao: SessionDao) {
+    suspend fun insert(session: SessionEntity) = dao.insert(session)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,12 +7,14 @@ composeBom = "2024.08.00"
 coreKtx = "1.13.1"
 activityCompose = "1.9.1"
 dataStore = "1.1.1"
+room = "2.6.1"
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 androidLibrary = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlinKapt = { id = "org.jetbrains.kotlin.kapt" }
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -23,4 +25,7 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "dataStore" }
+androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 


### PR DESCRIPTION
## Summary
- Save burst captures in timestamped session folders with RGB images, depth bag, optional note, and a meta.json
- Store capture session metadata and path using Room
- Configure project with Room dependencies

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68933f7d8480832aa80eec510f7ad37c