### PR TITLE
Add voice note recording

### DIFF
--- a/app/src/main/java/com/example/realsensecapture/VoiceNoteController.kt
+++ b/app/src/main/java/com/example/realsensecapture/VoiceNoteController.kt
@@ -1,0 +1,58 @@
+package com.example.realsensecapture
+
+import android.content.Context
+import android.media.MediaRecorder
+import com.example.realsensecapture.ui.VoiceNoteController as UiVoiceNoteController
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.io.File
+
+class VoiceNoteController(private val context: Context) : UiVoiceNoteController {
+    private var recorder: MediaRecorder? = null
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var levelJob: Job? = null
+    private val _level = MutableStateFlow(0f)
+    override val level: StateFlow<Float> = _level
+
+    override fun start(file: File) {
+        stop()
+        recorder = MediaRecorder().apply {
+            setAudioSource(MediaRecorder.AudioSource.MIC)
+            setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+            setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+            setAudioEncodingBitRate(96_000)
+            setAudioSamplingRate(44_100)
+            setOutputFile(file.absolutePath)
+            prepare()
+            start()
+        }
+        levelJob = scope.launch {
+            while (isActive) {
+                val amp = recorder?.maxAmplitude ?: 0
+                _level.value = amp / 32767f
+                delay(100L)
+            }
+        }
+    }
+
+    override fun stop() {
+        levelJob?.cancel()
+        levelJob = null
+        recorder?.apply {
+            try {
+                stop()
+            } catch (_: Exception) {
+            }
+            release()
+        }
+        recorder = null
+        _level.value = 0f
+    }
+}

--- a/ui/src/main/java/com/example/realsensecapture/data/SessionDao.kt
+++ b/ui/src/main/java/com/example/realsensecapture/data/SessionDao.kt
@@ -15,4 +15,7 @@ interface SessionDao {
 
     @Query("SELECT * FROM sessions WHERE id = :id")
     fun getById(id: Long): Flow<SessionEntity?>
+
+    @Query("UPDATE sessions SET hasNote = :hasNote WHERE id = :id")
+    suspend fun updateHasNote(id: Long, hasNote: Boolean)
 }

--- a/ui/src/main/java/com/example/realsensecapture/data/SessionRepository.kt
+++ b/ui/src/main/java/com/example/realsensecapture/data/SessionRepository.kt
@@ -6,4 +6,6 @@ class SessionRepository(private val dao: SessionDao) {
     fun getAll() = dao.getAll()
 
     fun getById(id: Long) = dao.getById(id)
+
+    suspend fun updateHasNote(id: Long, hasNote: Boolean) = dao.updateHasNote(id, hasNote)
 }

--- a/ui/src/main/java/com/example/realsensecapture/ui/VoiceNoteController.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/VoiceNoteController.kt
@@ -1,0 +1,10 @@
+package com.example.realsensecapture.ui
+
+import kotlinx.coroutines.flow.StateFlow
+import java.io.File
+
+interface VoiceNoteController {
+    val level: StateFlow<Float>
+    fun start(file: File)
+    fun stop()
+}


### PR DESCRIPTION
## Summary
- add `VoiceNoteController` to capture audio notes with level tracking
- wire up recording controls and level indicator in `SessionDetailsScreen`
- track audio note presence in Room database and `meta.json`

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689344a037c4832a8a3805fcd55dee3c