### PR TITLE
Switch depth recording to 848x480@60fps

### DIFF
--- a/rsnative/src/main/cpp/native-lib.cpp
+++ b/rsnative/src/main/cpp/native-lib.cpp
@@ -22,7 +22,10 @@ Java_com_example_realsensecapture_rsnative_NativeBridge_startPreview(
         JNIEnv*, jobject) {
     try {
         if (!is_streaming) {
-            pipeline.start();
+            rs2::config cfg;
+            cfg.enable_stream(RS2_STREAM_DEPTH, 848, 480, RS2_FORMAT_Z16, 60);
+            cfg.enable_stream(RS2_STREAM_COLOR, 640, 480, RS2_FORMAT_RGB8, 30);
+            pipeline.start(cfg);
             is_streaming = true;
         }
         return JNI_TRUE;
@@ -118,6 +121,8 @@ Java_com_example_realsensecapture_rsnative_NativeBridge_captureBurst(
     try {
         rs2::config cfg;
         std::string bagPath = directory + "/depth_0.1s.bag";
+        cfg.enable_stream(RS2_STREAM_DEPTH, 848, 480, RS2_FORMAT_Z16, 60);
+        cfg.enable_stream(RS2_STREAM_COLOR, 640, 480, RS2_FORMAT_RGB8, 30);
         cfg.enable_record_to_file(bagPath);
         rs2::pipeline p;
         p.start(cfg);

--- a/task.txt
+++ b/task.txt
@@ -87,7 +87,7 @@ UI (Compose) ── ViewModel (Coroutines/StateFlow) ── Domain Use‑cases �
 
 ## 7. Алгоритм записи бурста (C++)
 
-1. **Preview‑pipeline** (RGB 1280×720\@30 fps + Depth 640×480\@90 fps) работает постоянно.
+1. **Preview‑pipeline** (RGB 1280×720\@30 fps + Depth High‑Detail 848×480\@60 fps) работает постоянно.
 2. При триггере:
 
    * Создать временный pipeline с `config.enable_record_to_file(<dir>/depth_0.1s.bag)`.
@@ -150,7 +150,7 @@ UI (Compose) ── ViewModel (Coroutines/StateFlow) ── Domain Use‑cases �
 
 | Параметр               | Значение      |
 | ---------------------- | ------------- |
-| Depth Resolution / FPS | 640×480 @ 90  |
+| Depth Resolution / FPS | High‑Detail 848×480 @ 60 |
 | RGB Resolution  / FPS  | 1280×720 @ 30 |
 | Порог свободного места | 200 MB        |
 | JPEG качество          | 90 %          |

--- a/ui/src/main/java/com/example/realsensecapture/ui/PreviewScreen.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/PreviewScreen.kt
@@ -41,8 +41,8 @@ fun PreviewScreen(modifier: Modifier = Modifier) {
             val rgb = withContext(Dispatchers.IO) { NativeBridge.getRgbFrame() }
             val depth = withContext(Dispatchers.IO) { NativeBridge.getDepthFrame() }
             rgb?.let { rgbBitmap = rgbToBitmap(it, 640, 480) }
-            depth?.let { depthBitmap = depthToBitmap(it, 640, 480) }
-            delay(33L)
+            depth?.let { depthBitmap = depthToBitmap(it, 848, 480) }
+            delay(16L)
         }
     }
     DisposableEffect(Unit) {

--- a/ui/src/main/java/com/example/realsensecapture/ui/SettingsRepository.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/SettingsRepository.kt
@@ -16,8 +16,8 @@ class SettingsRepository(private val context: Context) {
     private val fpsKey = intPreferencesKey("fps")
     private val thresholdKey = longPreferencesKey("threshold")
 
-    val resolutionFlow: Flow<String> = context.dataStore.data.map { it[resolutionKey] ?: "640x480" }
-    val fpsFlow: Flow<Int> = context.dataStore.data.map { it[fpsKey] ?: 30 }
+    val resolutionFlow: Flow<String> = context.dataStore.data.map { it[resolutionKey] ?: "848x480" }
+    val fpsFlow: Flow<Int> = context.dataStore.data.map { it[fpsKey] ?: 60 }
     val thresholdFlow: Flow<Long> = context.dataStore.data.map { it[thresholdKey] ?: 100L * 1024 * 1024 }
 
     suspend fun setResolution(value: String) {

--- a/ui/src/main/java/com/example/realsensecapture/ui/SettingsScreen.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/SettingsScreen.kt
@@ -20,8 +20,8 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
     val repository = remember { SettingsRepository(context) }
     val scope = rememberCoroutineScope()
 
-    val resolution by repository.resolutionFlow.collectAsState(initial = "640x480")
-    val fps by repository.fpsFlow.collectAsState(initial = 30)
+    val resolution by repository.resolutionFlow.collectAsState(initial = "848x480")
+    val fps by repository.fpsFlow.collectAsState(initial = 60)
     val threshold by repository.thresholdFlow.collectAsState(initial = 100L * 1024 * 1024)
 
     Column(modifier.padding(16.dp)) {


### PR DESCRIPTION
## Summary
- Configure RealSense pipelines to stream depth at high-detail 848×480@60 fps
- Render depth preview at 848×480 and bump default resolution/FPS settings
- Document new depth parameters in project task list

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68934bdd4aa4832a8744634c082dc5c8