### PR TITLE
Add module manifests for ui and rsnative

### DIFF
--- a/rsnative/src/main/AndroidManifest.xml
+++ b/rsnative/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.example.realsensecapture.rsnative" />

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="com.example.realsensecapture.ui" />


### PR DESCRIPTION
## Summary
- add minimal AndroidManifest.xml for `ui` module
- add minimal AndroidManifest.xml for `rsnative` module

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895a7424724832a9fd36e21716c890e