### PR TITLE
Link prebuilt RealSense library in native module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 build
 
 gradle/wrapper/gradle-wrapper.jar
-rsnative/src/main/jniLibs/

--- a/rsnative/src/main/cpp/Findrealsense2.cmake
+++ b/rsnative/src/main/cpp/Findrealsense2.cmake
@@ -1,7 +1,17 @@
-find_path(realsense2_INCLUDE_DIR librealsense2/rs.hpp
-          HINTS ${CMAKE_CURRENT_LIST_DIR}/realsense2/include)
+find_path(
+    realsense2_INCLUDE_DIR
+    librealsense2/rs.hpp
+    HINTS ${CMAKE_CURRENT_LIST_DIR}/realsense2/include
+)
 
-add_library(realsense2::realsense2 INTERFACE)
+find_library(
+    realsense2_LIBRARY
+    NAMES realsense2 librealsense2
+    HINTS ${CMAKE_CURRENT_LIST_DIR}/../jniLibs/${ANDROID_ABI}
+)
+
+add_library(realsense2::realsense2 SHARED IMPORTED)
 set_target_properties(realsense2::realsense2 PROPERTIES
+    IMPORTED_LOCATION "${realsense2_LIBRARY}"
     INTERFACE_INCLUDE_DIRECTORIES "${realsense2_INCLUDE_DIR}"
 )


### PR DESCRIPTION
## Summary
- search for prebuilt `librealsense2` and expose it via `Findrealsense2.cmake`
- include placeholder `librealsense2.so` under jniLibs/arm64-v8a
- allow committing of native libraries by adjusting `.gitignore`

## Testing
- `./gradlew rsnative:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895a94dfe8c832aa40dd08102b3ebf2