### PR TITLE
Add required permissions for audio, storage, and USB host

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-feature android:name="android.hardware.usb.host" android:required="true" />
+
     <application android:label="@string/app_name">
         <provider
             android:name="androidx.core.content.FileProvider"


### PR DESCRIPTION
## Summary
- add `RECORD_AUDIO` permission to support audio recording
- include media and legacy storage permissions for exporting files
- declare USB host feature for RealSense OTG use

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895acdaa1b4832a8919916581f696dd