### PR TITLE
Implement Compose navigation shell and runtime permission gating

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
     kapt(libs.androidx.room.compiler)

--- a/app/src/main/java/com/example/realsensecapture/MainActivity.kt
+++ b/app/src/main/java/com/example/realsensecapture/MainActivity.kt
@@ -1,15 +1,212 @@
 package com.example.realsensecapture
 
+import android.Manifest
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.hardware.usb.UsbManager
+import android.os.Build
 import android.os.Bundle
+import android.content.Context.RECEIVER_NOT_EXPORTED
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.navigation.compose.rememberNavController
+import com.example.realsensecapture.data.AppDatabase
+import com.example.realsensecapture.data.SessionRepository
+import com.example.realsensecapture.ui.RealSenseCaptureApp
+import kotlinx.coroutines.flow.MutableStateFlow
 
 class MainActivity : ComponentActivity() {
+
+    private lateinit var sessionRepository: SessionRepository
+    private lateinit var voiceNoteController: VoiceNoteController
+    private var usbPermissionAction: String? = null
+    private val usbPermissionFlow = MutableStateFlow(true)
+    private var usbReceiverRegistered = false
+
+    private val usbPermissionReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == usbPermissionAction) {
+                usbPermissionFlow.value = hasUsbPermission()
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val database = AppDatabase.getInstance(applicationContext)
+        sessionRepository = SessionRepository(applicationContext, database.sessionDao())
+        voiceNoteController = VoiceNoteController(this)
+
+        usbPermissionAction = "${packageName}.USB_PERMISSION"
+        registerUsbReceiver()
+        usbPermissionFlow.value = hasUsbPermission()
+        if (!usbPermissionFlow.value) {
+            requestUsbPermission()
+        }
+
         setContent {
-            Text("Hello")
+            val requiredPermissions = remember { runtimePermissions() }
+            var hasStandardPermissions by rememberSaveable {
+                mutableStateOf(checkPermissions(requiredPermissions))
+            }
+            val permissionLauncher = rememberLauncherForActivityResult(
+                ActivityResultContracts.RequestMultiplePermissions()
+            ) { result ->
+                val granted = result.values.all { it }
+                hasStandardPermissions = granted || checkPermissions(requiredPermissions)
+            }
+            val hasUsbPermission by usbPermissionFlow.collectAsState()
+
+            LaunchedEffect(requiredPermissions) {
+                if (!hasStandardPermissions) {
+                    permissionLauncher.launch(requiredPermissions)
+                }
+            }
+
+            val permissionsGranted = hasStandardPermissions && hasUsbPermission
+            if (permissionsGranted) {
+                val navController = rememberNavController()
+                RealSenseCaptureApp(
+                    sessionRepository = sessionRepository,
+                    voiceNoteController = voiceNoteController,
+                    navController = navController,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                PermissionRequestScreen(
+                    hasStandardPermissions = hasStandardPermissions,
+                    hasUsbPermission = hasUsbPermission,
+                    onRequestStandardPermissions = {
+                        permissionLauncher.launch(requiredPermissions)
+                    },
+                    onRequestUsbPermission = { requestUsbPermission() }
+                )
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (usbReceiverRegistered) {
+            unregisterReceiver(usbPermissionReceiver)
+            usbReceiverRegistered = false
+        }
+        voiceNoteController.stop()
+    }
+
+    private fun runtimePermissions(): Array<String> {
+        val permissions = mutableListOf(Manifest.permission.RECORD_AUDIO)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            permissions += Manifest.permission.READ_MEDIA_IMAGES
+            permissions += Manifest.permission.READ_MEDIA_VIDEO
+        } else {
+            permissions += Manifest.permission.READ_EXTERNAL_STORAGE
+            permissions += Manifest.permission.WRITE_EXTERNAL_STORAGE
+        }
+        return permissions.distinct().toTypedArray()
+    }
+
+    private fun checkPermissions(permissions: Array<String>): Boolean =
+        permissions.all { permission ->
+            ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
+        }
+
+    private fun requestUsbPermission() {
+        val action = usbPermissionAction ?: return
+        val manager = usbManager()
+        val devices = manager.deviceList.values.filterNot { manager.hasPermission(it) }
+        if (devices.isEmpty()) {
+            usbPermissionFlow.value = true
+            return
+        }
+        val pendingIntent = PendingIntent.getBroadcast(
+            this,
+            0,
+            Intent(action),
+            PendingIntent.FLAG_IMMUTABLE
+        )
+        devices.forEach { device ->
+            manager.requestPermission(device, pendingIntent)
+        }
+    }
+
+    private fun hasUsbPermission(): Boolean {
+        val manager = usbManager()
+        val devices = manager.deviceList.values
+        if (devices.isEmpty()) return true
+        return devices.all { manager.hasPermission(it) }
+    }
+
+    private fun registerUsbReceiver() {
+        val action = usbPermissionAction ?: return
+        val filter = IntentFilter(action)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(usbPermissionReceiver, filter, RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("DEPRECATION")
+            registerReceiver(usbPermissionReceiver, filter)
+        }
+        usbReceiverRegistered = true
+    }
+
+    private fun usbManager(): UsbManager = getSystemService(UsbManager::class.java)
+
+    @Composable
+    private fun PermissionRequestScreen(
+        hasStandardPermissions: Boolean,
+        hasUsbPermission: Boolean,
+        onRequestStandardPermissions: () -> Unit,
+        onRequestUsbPermission: () -> Unit
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text("Permissions are required to use the camera features.")
+            Spacer(modifier = Modifier.height(16.dp))
+            if (!hasStandardPermissions) {
+                Button(onClick = onRequestStandardPermissions) {
+                    Text("Grant microphone and storage access")
+                }
+            }
+            if (!hasUsbPermission) {
+                Button(
+                    onClick = onRequestUsbPermission,
+                    modifier = Modifier.padding(top = 16.dp)
+                ) {
+                    Text("Grant USB access")
+                }
+            }
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ lifecycle = "2.8.4"
 junit = "4.13.2"
 androidxTestExtJunit = "1.1.5"
 espressoCore = "3.5.1"
+navigationCompose = "2.7.7"
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "androidGradlePlugin" }
@@ -33,6 +34,7 @@ androidx-room-runtime = { group = "androidx.room", name = "room-runtime", versio
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
+    implementation(libs.androidx.navigation.compose)
     kapt(libs.androidx.room.compiler)
     debugImplementation(libs.androidx.compose.ui.tooling)
     implementation(libs.androidx.lifecycle.runtime.compose)

--- a/ui/src/main/java/com/example/realsensecapture/ui/GalleryScreen.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/GalleryScreen.kt
@@ -5,12 +5,15 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -18,13 +21,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.example.realsensecapture.data.AppDatabase
 import com.example.realsensecapture.data.SessionEntity
+import com.example.realsensecapture.data.SessionRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -34,16 +37,32 @@ import java.time.format.DateTimeFormatter
 
 @Composable
 fun GalleryScreen(
+    sessionRepository: SessionRepository,
     modifier: Modifier = Modifier,
-    onSessionClick: (SessionEntity) -> Unit = {}
+    onSessionClick: (SessionEntity) -> Unit = {},
+    onNavigateBack: () -> Unit = {}
 ) {
-    val context = LocalContext.current
-    val dao = remember { AppDatabase.getInstance(context).sessionDao() }
-    val sessions by dao.getAll().collectAsState(initial = emptyList())
+    val sessionsFlow = remember(sessionRepository) { sessionRepository.getAll() }
+    val sessions by sessionsFlow.collectAsState(initial = emptyList())
 
-    LazyColumn(modifier) {
-        items(sessions) { session ->
-            SessionItem(session = session, onClick = { onSessionClick(session) })
+    Column(modifier = modifier.fillMaxSize()) {
+        TextButton(
+            onClick = onNavigateBack,
+            modifier = Modifier
+                .align(Alignment.Start)
+                .padding(8.dp)
+        ) {
+            Text("Back")
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+        ) {
+            items(sessions) { session ->
+                SessionItem(session = session, onClick = { onSessionClick(session) })
+            }
         }
     }
 }

--- a/ui/src/main/java/com/example/realsensecapture/ui/PreviewScreen.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/PreviewScreen.kt
@@ -1,9 +1,45 @@
 package com.example.realsensecapture.ui
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.matchParentSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
-fun PreviewScreen(modifier: Modifier = Modifier) {
-    PreviewSurface(modifier = modifier)
+fun PreviewScreen(
+    modifier: Modifier = Modifier,
+    onNavigateToGallery: () -> Unit = {},
+    onNavigateToSettings: () -> Unit = {}
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        PreviewSurface(modifier = Modifier.matchParentSize())
+
+        Column(
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.End
+        ) {
+            Button(onClick = onNavigateToSettings) {
+                Text("Settings")
+            }
+        }
+
+        FloatingActionButton(
+            onClick = onNavigateToGallery,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp)
+        ) {
+            Text("Gallery")
+        }
+    }
 }

--- a/ui/src/main/java/com/example/realsensecapture/ui/RealSenseCaptureApp.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/RealSenseCaptureApp.kt
@@ -1,0 +1,70 @@
+package com.example.realsensecapture.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavType
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.example.realsensecapture.data.SessionRepository
+
+@Composable
+fun RealSenseCaptureApp(
+    sessionRepository: SessionRepository,
+    voiceNoteController: VoiceNoteController,
+    navController: NavHostController,
+    modifier: Modifier = Modifier
+) {
+    NavHost(
+        navController = navController,
+        startDestination = Screen.Preview.route,
+        modifier = modifier
+    ) {
+        composable(Screen.Preview.route) {
+            PreviewScreen(
+                onNavigateToGallery = { navController.navigate(Screen.Gallery.route) },
+                onNavigateToSettings = { navController.navigate(Screen.Settings.route) }
+            )
+        }
+        composable(Screen.Gallery.route) {
+            GalleryScreen(
+                sessionRepository = sessionRepository,
+                onSessionClick = { session ->
+                    navController.navigate(Screen.SessionDetails.createRoute(session.id))
+                },
+                onNavigateBack = { navController.popBackStack() }
+            )
+        }
+        composable(
+            route = Screen.SessionDetails.route,
+            arguments = listOf(
+                navArgument(Screen.SessionDetails.ARG_ID) { type = NavType.LongType }
+            )
+        ) { entry ->
+            val sessionId = entry.arguments?.getLong(Screen.SessionDetails.ARG_ID)
+                ?: return@composable
+            SessionDetailsScreen(
+                sessionId = sessionId,
+                controller = voiceNoteController,
+                sessionRepository = sessionRepository,
+                onNavigateBack = { navController.popBackStack() }
+            )
+        }
+        composable(Screen.Settings.route) {
+            SettingsScreen(
+                onNavigateBack = { navController.popBackStack() }
+            )
+        }
+    }
+}
+
+private sealed class Screen(val route: String) {
+    data object Preview : Screen("preview")
+    data object Gallery : Screen("gallery")
+    data object Settings : Screen("settings")
+    data object SessionDetails : Screen("details/{sessionId}") {
+        const val ARG_ID = "sessionId"
+        fun createRoute(id: Long) = "details/$id"
+    }
+}

--- a/ui/src/main/java/com/example/realsensecapture/ui/SettingsScreen.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/SettingsScreen.kt
@@ -1,9 +1,11 @@
 package com.example.realsensecapture.ui
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -15,7 +17,10 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
 @Composable
-fun SettingsScreen(modifier: Modifier = Modifier) {
+fun SettingsScreen(
+    modifier: Modifier = Modifier,
+    onNavigateBack: () -> Unit = {}
+) {
     val context = LocalContext.current
     val repository = remember { SettingsRepository(context) }
     val scope = rememberCoroutineScope()
@@ -24,7 +29,8 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
     val fps by repository.fpsFlow.collectAsState(initial = 60)
     val threshold by repository.thresholdFlow.collectAsState(initial = 100L * 1024 * 1024)
 
-    Column(modifier.padding(16.dp)) {
+    Column(modifier.fillMaxSize().padding(16.dp)) {
+        TextButton(onClick = onNavigateBack) { Text("Back") }
         OutlinedTextField(
             value = resolution,
             onValueChange = { new -> scope.launch { repository.setResolution(new) } },


### PR DESCRIPTION
## Summary
- introduce a RealSenseCaptureApp composable that wires preview, gallery, details and settings screens through a shared NavHost
- refactor gallery, details and settings screens to accept shared repositories/callbacks and add simple navigation affordances
- initialize Room, repositories and voice note controller in MainActivity while gating the UI behind microphone, storage and USB permissions
- add the Navigation Compose dependency to both app and ui modules

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e22f417d98832ab391b4c47a9273ad