### PR TITLE
Add capture controls to preview screen

### DIFF
--- a/ui/src/main/java/com/example/realsensecapture/ui/PreviewScreen.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/PreviewScreen.kt
@@ -1,24 +1,46 @@
 package com.example.realsensecapture.ui
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExtendedFloatingActionButton
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.example.realsensecapture.data.SessionRepository
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
 
 @Composable
 fun PreviewScreen(
+    sessionRepository: SessionRepository,
     modifier: Modifier = Modifier,
     onNavigateToGallery: () -> Unit = {},
-    onNavigateToSettings: () -> Unit = {}
+    onNavigateToSettings: () -> Unit = {},
+    onCaptureSuccess: () -> Unit = onNavigateToGallery
 ) {
+    var isCapturing by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    val scope = rememberCoroutineScope()
+
     Box(modifier = modifier.fillMaxSize()) {
         PreviewSurface(modifier = Modifier.matchParentSize())
 
@@ -33,13 +55,65 @@ fun PreviewScreen(
             }
         }
 
-        FloatingActionButton(
-            onClick = onNavigateToGallery,
+        Column(
             modifier = Modifier
                 .align(Alignment.BottomEnd)
-                .padding(16.dp)
+                .padding(16.dp),
+            horizontalAlignment = Alignment.End,
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Text("Gallery")
+            errorMessage?.let { message ->
+                Text(
+                    text = message,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+
+            ExtendedFloatingActionButton(
+                onClick = {
+                    if (isCapturing) return@ExtendedFloatingActionButton
+                    scope.launch {
+                        isCapturing = true
+                        errorMessage = null
+
+                        val success = try {
+                            sessionRepository.createSession()
+                        } catch (t: Throwable) {
+                            if (t is CancellationException) throw t
+                            errorMessage = t.message ?: "Failed to start capture"
+                            false
+                        }
+
+                        isCapturing = false
+
+                        if (success) {
+                            onCaptureSuccess()
+                        } else if (errorMessage == null) {
+                            errorMessage = "Failed to create session"
+                        }
+                    }
+                },
+                enabled = !isCapturing
+            ) {
+                if (isCapturing) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(24.dp),
+                            strokeWidth = 2.dp
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text("Capturing…")
+                    }
+                } else {
+                    Text("Start Capture")
+                }
+            }
+
+            FloatingActionButton(
+                onClick = onNavigateToGallery
+            ) {
+                Text("Gallery")
+            }
         }
     }
 }

--- a/ui/src/main/java/com/example/realsensecapture/ui/RealSenseCaptureApp.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/RealSenseCaptureApp.kt
@@ -16,6 +16,12 @@ fun RealSenseCaptureApp(
     navController: NavHostController,
     modifier: Modifier = Modifier
 ) {
+    val navigateToGallery: () -> Unit = {
+        navController.navigate(Screen.Gallery.route) {
+            launchSingleTop = true
+        }
+    }
+
     NavHost(
         navController = navController,
         startDestination = Screen.Preview.route,
@@ -23,8 +29,10 @@ fun RealSenseCaptureApp(
     ) {
         composable(Screen.Preview.route) {
             PreviewScreen(
-                onNavigateToGallery = { navController.navigate(Screen.Gallery.route) },
-                onNavigateToSettings = { navController.navigate(Screen.Settings.route) }
+                sessionRepository = sessionRepository,
+                onNavigateToGallery = navigateToGallery,
+                onNavigateToSettings = { navController.navigate(Screen.Settings.route) },
+                onCaptureSuccess = navigateToGallery
             )
         }
         composable(Screen.Gallery.route) {


### PR DESCRIPTION
## Summary
- invoke the session repository from the preview screen to start a capture
- show capture progress and errors while disabling the button until completion
- notify the host via the nav controller so the gallery opens after a successful capture

## Testing
- ./gradlew :ui:assembleDebug *(fails: Android SDK not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2322851dc832a8b527aa387440698