### PR TITLE
Ensure preview streaming resumes after capture

### DIFF
--- a/ui/src/main/java/com/example/realsensecapture/ui/PreviewScreen.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/PreviewScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.realsensecapture.data.SessionRepository
+import com.example.realsensecapture.rsnative.NativeBridge
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
@@ -77,11 +78,14 @@ fun PreviewScreen(
                         errorMessage = null
 
                         val success = try {
+                            NativeBridge.stopStreaming()
                             sessionRepository.createSession()
                         } catch (t: Throwable) {
                             if (t is CancellationException) throw t
                             errorMessage = t.message ?: "Failed to start capture"
                             false
+                        } finally {
+                            NativeBridge.startStreaming()
                         }
 
                         isCapturing = false

--- a/ui/src/main/java/com/example/realsensecapture/ui/PreviewSurface.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/PreviewSurface.kt
@@ -38,9 +38,13 @@ fun PreviewSurface(modifier: Modifier = Modifier) {
                 val frame = NativeBridge.getCombinedFrame()
                 frame?.let {
                     val bmp = frameToBitmap(it, width, height)
-                    val canvas = surfaceView.holder.lockCanvas()
+                    val holder = surfaceView.holder
+                    if (!holder.surface.isValid) {
+                        return@let
+                    }
+                    val canvas = holder.lockCanvas()
                     canvas.drawBitmap(bmp, 0f, 0f, null)
-                    surfaceView.holder.unlockCanvasAndPost(canvas)
+                    holder.unlockCanvasAndPost(canvas)
                 }
                 delay(16L)
             }


### PR DESCRIPTION
## Summary
- stop the preview stream before creating a new capture session and restart it afterward to guarantee preview resumes
- guard PreviewSurface drawing against invalid surfaces so frames recover after temporary stream interruption

## Testing
- ./gradlew :ui:assembleDebug *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cb121dbc832aa319c9b98206c417