### PR TITLE
Handle capture storage limits and fix preview width

### DIFF
--- a/app/src/main/java/com/example/realsensecapture/MainActivity.kt
+++ b/app/src/main/java/com/example/realsensecapture/MainActivity.kt
@@ -39,12 +39,14 @@ import androidx.navigation.compose.rememberNavController
 import com.example.realsensecapture.data.AppDatabase
 import com.example.realsensecapture.data.SessionRepository
 import com.example.realsensecapture.ui.RealSenseCaptureApp
+import com.example.realsensecapture.ui.SettingsRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 
 class MainActivity : ComponentActivity() {
 
     private lateinit var sessionRepository: SessionRepository
     private lateinit var voiceNoteController: VoiceNoteController
+    private lateinit var settingsRepository: SettingsRepository
     private var usbPermissionAction: String? = null
     private val usbPermissionFlow = MutableStateFlow(true)
     private var usbReceiverRegistered = false
@@ -63,6 +65,7 @@ class MainActivity : ComponentActivity() {
         val database = AppDatabase.getInstance(applicationContext)
         sessionRepository = SessionRepository(applicationContext, database.sessionDao())
         voiceNoteController = VoiceNoteController(this)
+        settingsRepository = SettingsRepository(applicationContext)
 
         usbPermissionAction = "${packageName}.USB_PERMISSION"
         registerUsbReceiver()
@@ -96,6 +99,7 @@ class MainActivity : ComponentActivity() {
                 RealSenseCaptureApp(
                     sessionRepository = sessionRepository,
                     voiceNoteController = voiceNoteController,
+                    settingsRepository = settingsRepository,
                     navController = navController,
                     modifier = Modifier.fillMaxSize()
                 )

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,10 @@
 ## RealSense Capture
 
 Android приложение для записи и просмотра RGB + Depth с камер Intel RealSense.
+
+### Текущий статус
+
+* **Интерфейс Compose подключён.** `MainActivity` разворачивает `RealSenseCaptureApp`, где настроена навигация между экранами предпросмотра, галереи, деталей и настроек, а также прокидываются зависимости `SessionRepository` и `VoiceNoteController`. 【F:app/src/main/java/com/example/realsensecapture/MainActivity.kt†L46-L118】【F:ui/src/main/java/com/example/realsensecapture/ui/RealSenseCaptureApp.kt†L13-L60】
+* **Предпросмотр и запись бурста доступны.** Экран предпросмотра отображает поток через `PreviewSurface`, управляет правами и позволяет запускать `SessionRepository.createSession()`, предварительно приостанавливая стрим через `NativeBridge.stopStreaming()` и возобновляя его по завершении. 【F:ui/src/main/java/com/example/realsensecapture/ui/PreviewScreen.kt†L33-L118】
+* **Ширина предпросмотра выровнена с нативным буфером.** Вместо жёсткого 1280×480 `PreviewSurface` теперь отрисовывает фактический кадр 1488×480 (640 RGB + 848 Depth) и пропускает повреждённые буферы, поэтому глубина не обрезается. 【F:ui/src/main/java/com/example/realsensecapture/ui/PreviewSurface.kt†L33-L69】【F:rsnative/src/main/cpp/native-lib.cpp†L73-L116】
+* **Перед записью проверяется свободное место (F‑8).** `PreviewScreen` читает порог из `SettingsRepository`, сверяет его с `SessionRepository.getAvailableSpaceBytes()` и блокирует бурст, если памяти < порога. Пустые каталоги теперь очищаются, если `captureBurst` вернул `false`. 【F:ui/src/main/java/com/example/realsensecapture/ui/PreviewScreen.kt†L36-L107】【F:ui/src/main/java/com/example/realsensecapture/data/SessionRepository.kt†L44-L77】【F:ui/src/main/java/com/example/realsensecapture/ui/SettingsRepository.kt†L13-L24】

--- a/ui/src/main/java/com/example/realsensecapture/ui/PreviewScreen.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/PreviewScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,6 +34,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun PreviewScreen(
     sessionRepository: SessionRepository,
+    settingsRepository: SettingsRepository,
     modifier: Modifier = Modifier,
     onNavigateToGallery: () -> Unit = {},
     onNavigateToSettings: () -> Unit = {},
@@ -41,6 +43,8 @@ fun PreviewScreen(
     var isCapturing by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     val scope = rememberCoroutineScope()
+    val freeSpaceThreshold by settingsRepository.thresholdFlow
+        .collectAsState(initial = SettingsRepository.DEFAULT_THRESHOLD_BYTES)
 
     Box(modifier = modifier.fillMaxSize()) {
         PreviewSurface(modifier = Modifier.matchParentSize())
@@ -77,15 +81,37 @@ fun PreviewScreen(
                         isCapturing = true
                         errorMessage = null
 
+                        val freeBytes = try {
+                            sessionRepository.getAvailableSpaceBytes()
+                        } catch (t: Throwable) {
+                            if (t is CancellationException) throw t
+                            errorMessage = t.message ?: "Unable to check free space"
+                            isCapturing = false
+                            return@launch
+                        }
+
+                        if (freeBytes < freeSpaceThreshold) {
+                            val requiredMb = freeSpaceThreshold / (1024 * 1024)
+                            val availableMb = freeBytes / (1024 * 1024)
+                            errorMessage =
+                                "Not enough free space (required ≥ ${'$'}requiredMb MB, available ${'$'}availableMb MB)"
+                            isCapturing = false
+                            return@launch
+                        }
+
+                        var streamingStopped = false
                         val success = try {
                             NativeBridge.stopStreaming()
+                            streamingStopped = true
                             sessionRepository.createSession()
                         } catch (t: Throwable) {
                             if (t is CancellationException) throw t
                             errorMessage = t.message ?: "Failed to start capture"
                             false
                         } finally {
-                            NativeBridge.startStreaming()
+                            if (streamingStopped) {
+                                NativeBridge.startStreaming()
+                            }
                         }
 
                         isCapturing = false

--- a/ui/src/main/java/com/example/realsensecapture/ui/PreviewSurface.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/PreviewSurface.kt
@@ -32,11 +32,14 @@ fun PreviewSurface(modifier: Modifier = Modifier) {
     LaunchedEffect(surfaceView) {
         withContext(Dispatchers.IO) {
             NativeBridge.startStreaming()
-            val width = 1280
+            val rgbWidth = 640
+            val depthWidth = 848
+            val width = rgbWidth + depthWidth
             val height = 480
+            val expectedSize = width * height * 3
             while (isActive) {
                 val frame = NativeBridge.getCombinedFrame()
-                frame?.let {
+                frame?.takeIf { it.size >= expectedSize }?.let {
                     val bmp = frameToBitmap(it, width, height)
                     val holder = surfaceView.holder
                     if (!holder.surface.isValid) {
@@ -90,8 +93,9 @@ fun PreviewSurface(modifier: Modifier = Modifier) {
 
 private fun frameToBitmap(data: ByteArray, width: Int, height: Int): Bitmap {
     val pixels = IntArray(width * height)
+    val availablePixels = minOf(pixels.size, data.size / 3)
     var i = 0
-    for (p in pixels.indices) {
+    for (p in 0 until availablePixels) {
         val r = data[i++].toInt() and 0xFF
         val g = data[i++].toInt() and 0xFF
         val b = data[i++].toInt() and 0xFF

--- a/ui/src/main/java/com/example/realsensecapture/ui/RealSenseCaptureApp.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/RealSenseCaptureApp.kt
@@ -13,6 +13,7 @@ import com.example.realsensecapture.data.SessionRepository
 fun RealSenseCaptureApp(
     sessionRepository: SessionRepository,
     voiceNoteController: VoiceNoteController,
+    settingsRepository: SettingsRepository,
     navController: NavHostController,
     modifier: Modifier = Modifier
 ) {
@@ -30,6 +31,7 @@ fun RealSenseCaptureApp(
         composable(Screen.Preview.route) {
             PreviewScreen(
                 sessionRepository = sessionRepository,
+                settingsRepository = settingsRepository,
                 onNavigateToGallery = navigateToGallery,
                 onNavigateToSettings = { navController.navigate(Screen.Settings.route) },
                 onCaptureSuccess = navigateToGallery
@@ -61,6 +63,7 @@ fun RealSenseCaptureApp(
         }
         composable(Screen.Settings.route) {
             SettingsScreen(
+                settingsRepository = settingsRepository,
                 onNavigateBack = { navController.popBackStack() }
             )
         }

--- a/ui/src/main/java/com/example/realsensecapture/ui/SettingsRepository.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/SettingsRepository.kt
@@ -12,13 +12,16 @@ import kotlinx.coroutines.flow.map
 private val Context.dataStore by preferencesDataStore("settings")
 
 class SettingsRepository(private val context: Context) {
+    companion object {
+        const val DEFAULT_THRESHOLD_BYTES: Long = 200L * 1024 * 1024
+    }
     private val resolutionKey = stringPreferencesKey("resolution")
     private val fpsKey = intPreferencesKey("fps")
     private val thresholdKey = longPreferencesKey("threshold")
 
     val resolutionFlow: Flow<String> = context.dataStore.data.map { it[resolutionKey] ?: "848x480" }
     val fpsFlow: Flow<Int> = context.dataStore.data.map { it[fpsKey] ?: 60 }
-    val thresholdFlow: Flow<Long> = context.dataStore.data.map { it[thresholdKey] ?: 100L * 1024 * 1024 }
+    val thresholdFlow: Flow<Long> = context.dataStore.data.map { it[thresholdKey] ?: DEFAULT_THRESHOLD_BYTES }
 
     suspend fun setResolution(value: String) {
         context.dataStore.edit { it[resolutionKey] = value }

--- a/ui/src/main/java/com/example/realsensecapture/ui/SettingsScreen.kt
+++ b/ui/src/main/java/com/example/realsensecapture/ui/SettingsScreen.kt
@@ -9,43 +9,48 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 
 @Composable
 fun SettingsScreen(
+    settingsRepository: SettingsRepository,
     modifier: Modifier = Modifier,
-    onNavigateBack: () -> Unit = {}
+    onNavigateBack: () -> Unit = {},
 ) {
-    val context = LocalContext.current
-    val repository = remember { SettingsRepository(context) }
     val scope = rememberCoroutineScope()
 
-    val resolution by repository.resolutionFlow.collectAsState(initial = "848x480")
-    val fps by repository.fpsFlow.collectAsState(initial = 60)
-    val threshold by repository.thresholdFlow.collectAsState(initial = 100L * 1024 * 1024)
+    val resolution by settingsRepository.resolutionFlow.collectAsState(initial = "848x480")
+    val fps by settingsRepository.fpsFlow.collectAsState(initial = 60)
+    val threshold by settingsRepository.thresholdFlow
+        .collectAsState(initial = SettingsRepository.DEFAULT_THRESHOLD_BYTES)
 
     Column(modifier.fillMaxSize().padding(16.dp)) {
         TextButton(onClick = onNavigateBack) { Text("Back") }
         OutlinedTextField(
             value = resolution,
-            onValueChange = { new -> scope.launch { repository.setResolution(new) } },
+            onValueChange = { new -> scope.launch { settingsRepository.setResolution(new) } },
             label = { Text("Resolution") }
         )
         OutlinedTextField(
             value = fps.toString(),
-            onValueChange = { new -> new.toIntOrNull()?.let { scope.launch { repository.setFps(it) } } },
+            onValueChange = { new ->
+                new.toIntOrNull()?.let { value ->
+                    scope.launch { settingsRepository.setFps(value) }
+                }
+            },
             label = { Text("FPS") }
         )
         OutlinedTextField(
             value = threshold.toString(),
-            onValueChange = { new -> new.toLongOrNull()?.let { scope.launch { repository.setThreshold(it) } } },
+            onValueChange = { new ->
+                new.toLongOrNull()?.let { value ->
+                    scope.launch { settingsRepository.setThreshold(value) }
+                }
+            },
             label = { Text("Free space threshold (bytes)") }
         )
     }
 }
-


### PR DESCRIPTION
## Summary
- wire the shared SettingsRepository through the app so the preview screen and settings screen use a common free-space threshold
- prevent burst capture when storage is below the configured limit, clean up failed sessions, and document the new behavior
- render the full 1488px combined RGB+depth buffer in the preview surface so depth data is no longer cropped

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e22e18cf3c832abc66e860058109ee